### PR TITLE
fixed bug when removing queries without any hard positives

### DIFF
--- a/datasets_ws.py
+++ b/datasets_ws.py
@@ -188,6 +188,7 @@ class TripletsDataset(BaseDataset):
                          "within the training set. They won't be considered as they're useless for training.")
         # Remove queries without positives
         self.hard_positives_per_query = np.delete(self.hard_positives_per_query, queries_without_any_hard_positive)
+        self.soft_positives_per_query = np.delete(self.soft_positives_per_query, queries_without_any_hard_positive)
         self.queries_paths = np.delete(self.queries_paths, queries_without_any_hard_positive)
         
         # Recompute images_paths and queries_num because some queries might have been removed


### PR DESCRIPTION
In datasets_ws.py line 190, the variable hard_positives_per_query is changed by removing all the queries without any hard positives. The same is not done for soft_positives_per_query, therefore in lines 313, 337, 375 the variable soft_positives may not refer to the actual desired query. 